### PR TITLE
PostgreSQL support

### DIFF
--- a/modules/base/files/puppet.conf
+++ b/modules/base/files/puppet.conf
@@ -6,7 +6,7 @@ rundir=/var/run/puppet
 factpath=$vardir/lib/facter
 pluginsync=false
 templatedir=$confdir/templates
-server=puppet.c--g.net
+server=puppetmaster.local
 preferred_serialization_format=yaml
 
 [puppetd]

--- a/modules/pgsql/files/pg_hba.conf
+++ b/modules/pgsql/files/pg_hba.conf
@@ -1,0 +1,83 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the
+# PostgreSQL documentation for a complete description
+# of this file.  A short synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTION]
+# host       DATABASE  USER  CIDR-ADDRESS  METHOD  [OPTION]
+# hostssl    DATABASE  USER  CIDR-ADDRESS  METHOD  [OPTION]
+# hostnossl  DATABASE  USER  CIDR-ADDRESS  METHOD  [OPTION]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain socket,
+# "host" is either a plain or SSL-encrypted TCP/IP socket, "hostssl" is an
+# SSL-encrypted TCP/IP socket, and "hostnossl" is a plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", a database name, or
+# a comma-separated list thereof.
+#
+# USER can be "all", a user name, a group name prefixed with "+", or
+# a comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names from
+# a separate file.
+#
+# CIDR-ADDRESS specifies the set of hosts the record matches.
+# It is made up of an IP address and a CIDR mask that is an integer
+# (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that specifies
+# the number of significant bits in the mask.  Alternatively, you can write
+# an IP address and netmask in separate columns to specify the set of hosts.
+#
+# METHOD can be "trust", "reject", "md5", "crypt", "password", "gss", "sspi",
+# "krb5", "ident", "pam" or "ldap".  Note that "password" sends passwords
+# in clear text; "md5" is preferred since it sends encrypted passwords.
+#
+# OPTION is the ident map or the name of the PAM service, depending on METHOD.
+#
+# Database and user names containing spaces, commas, quotes and other special
+# characters must be quoted. Quoting one of the keywords "all", "sameuser" or
+# "samerole" makes the name lose its special character, and just match a
+# database or username with that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can use
+# "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records. In that case you will also need to make PostgreSQL listen
+# on a non-local interface via the listen_addresses configuration parameter,
+# or via the -i or -h command line switches.
+#
+
+
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database
+# super user can access the database using some other method.
+# Noninteractive
+# access to all databases is required during automatic maintenance
+# (autovacuum, daily cronjob, replication, and similar tasks).
+#
+# Database administrative login by UNIX sockets
+local   all         postgres                          ident sameuser
+
+# TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
+
+# "local" is for Unix domain socket connections only
+local   all         all                               trust
+# IPv4 local connections:
+host    all         all         127.0.0.1/32          trust
+# IPv6 local connections:
+host    all         all         ::1/128               trust

--- a/modules/pgsql/files/postgresql.conf
+++ b/modules/pgsql/files/postgresql.conf
@@ -1,0 +1,494 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some paramters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes MB = megabytes GB = gigabytes
+# Time units:    ms = milliseconds s = seconds min = minutes h = hours d = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '/tmpfs/postgresql/8.3/main'		# use data in another directory
+					# (change requires restart)
+hba_file = '/etc/postgresql/8.3/main/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+ident_file = '/etc/postgresql/8.3/main/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+external_pid_file = '/var/run/postgresql/8.3-main.pid'		# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+#listen_addresses = 'localhost'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost', '*' = all
+					# (change requires restart)
+port = 5432				# (change requires restart)
+max_connections = 100			# (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per 
+# connection slot, plus lock space (see max_locks_per_transaction).  You might
+# also need to raise shared_buffers to support more connections.
+#superuser_reserved_connections = 3	# (change requires restart)
+unix_socket_directory = '/var/run/postgresql'		# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+ssl = off				# (change requires restart)
+#ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
+					# (change requires restart)
+#ssl_renegotiation_limit = 512MB	# amount of data between renegotiations
+#password_encryption = on
+#db_user_namespace = off
+
+# Kerberos and GSSAPI
+#krb_server_keyfile = ''		# (change requires restart)
+#krb_srvname = 'postgres'		# (change requires restart, Kerberos only)
+#krb_server_hostname = ''		# empty string matches any keytab entry
+					# (change requires restart, Kerberos only)
+#krb_caseins_users = off		# (change requires restart)
+#krb_realm = ''           		# (change requires restart)
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 64MB			# min 128kB or max_connections*16kB
+					# (change requires restart)
+temp_buffers = 32MB			# min 800kB
+max_prepared_transactions = 0		# can be 0 or more
+					# (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+work_mem = 16MB				# min 64kB
+#maintenance_work_mem = 16MB		# min 1MB
+max_stack_depth = 7680kB			# min 100kB
+
+# - Free Space Map -
+
+max_fsm_pages = 153600			# min max_fsm_relations*16, 6 bytes each
+					# (change requires restart)
+#max_fsm_relations = 1000		# min 100, ~70 bytes each
+					# (change requires restart)
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000		# min 25
+					# (change requires restart)
+#shared_preload_libraries = ''		# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-1000 milliseconds
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multipler on buffers scanned/round
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+fsync = off				# turns forced synchronization on or off
+synchronous_commit = off		# immediate fsync at commit
+wal_sync_method = fdatasync		# the default is the first option 
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+#full_page_writes = on			# recover from partial page writes
+#wal_buffers = 64kB			# min 32kB
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+checkpoint_segments = 5		# in logfile segments, min 1, 16MB each
+#checkpoint_timeout = 5min		# range 30s-1h
+#checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s		# 0 is off
+
+# - Archiving -
+
+#archive_mode = off		# allows archiving to be done
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+#archive_timeout = 0		# force a logfile segment switch after this
+				# time; 0 is off
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#effective_cache_size = 128MB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 10		# range 1-1000
+#constraint_exclusion = off
+#from_collapse_limit = 8
+#join_collapse_limit = 8		# 1 disables collapsing of explicit 
+					# JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'		# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+					# can include strftime() escapes
+#log_truncate_on_rotation = off		# If on, an existing log file of the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 to disable.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will 
+					# happen after that much log output.
+					# 0 to disable.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+
+# - When to Log -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+
+#log_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_error_verbosity = default		# terse, default, or verbose messages
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+				 	#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+				 	#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this time.
+
+#silent_mode = off			# DO NOT USE without syslog or
+					# logging_collector
+					# (change requires restart)
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = off
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_hostname = off
+log_line_prefix = '%t '			# special values:
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %p = process ID
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %i = command tag
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_statement = 'none'			# none, ddl, mod, all
+#log_temp_files = -1			# log temporary files equal or larger
+					# than specified size;
+					# -1 disables, 0 logs all temp files
+#log_timezone = unknown			# actually, defaults to TZ environment
+					# setting
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#update_process_title = on
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+autovacuum = on			# Enable autovacuum subprocess?  'on' 
+					# requires track_counts to also be on.
+#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least that time.
+autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+autovacuum_naptime = 1s		# time between autovacuum runs
+autovacuum_vacuum_threshold = 10	# min number of row updates before
+					# vacuum
+#autovacuum_analyze_threshold = 50	# min number of row updates before 
+					# analyze
+autovacuum_vacuum_scale_factor = 0.1	# fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+autovacuum_vacuum_cost_delay = 0	# default vacuum cost delay for
+					# autovacuum, -1 means use
+					# vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'		# schema names
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# 0 is disabled
+#vacuum_freeze_min_age = 100000000
+#xmlbinary = 'base64'
+#xmloption = 'content'
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#timezone = unknown			# actually, defaults to TZ environment
+					# setting
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 0			# min -15, max 2
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'			# locale for number formatting
+lc_time = 'en_US.UTF-8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#explain_pretty_print = on
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+deadlock_timeout = 5s
+max_locks_per_transaction = 1000		# min 10
+					# (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#add_missing_from = off
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#default_with_oids = off
+escape_string_warning = off
+#regex_flavor = advanced		# advanced, extended, or basic
+#sql_inheritance = on
+#standard_conforming_strings = off
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+#custom_variable_classes = ''		# list of custom variable class names

--- a/modules/pgsql/files/shmmax.conf
+++ b/modules/pgsql/files/shmmax.conf
@@ -1,0 +1,3 @@
+# Sysctl written by Puppet pgsql config
+kernel.shmmax = 214748364
+

--- a/modules/pgsql/manifests/init.pp
+++ b/modules/pgsql/manifests/init.pp
@@ -1,0 +1,56 @@
+
+class pgsql {
+  class server {
+    # TODO: Sort out locales, which are breaking pg_createcluster
+
+    file { "/etc/sysctl.d/shmmax.conf":
+      owner   => root,
+      group   => root,
+      mode    => 755,
+      source  => "puppet://$servername/modules/pgsql/shmmax.conf",
+      require => Package["postgresql-8.3"],
+      notify  => Exec["shmmax-sysctl"]
+    }
+
+    exec { "shmmax-sysctl":
+      path    => "/usr/bin:/bin:/usr/sbin:/sbin",
+      command => "/sbin/sysctl -p /etc/sysctl.d/shmmax.conf",
+    }
+
+    package { "postgresql-8.3":
+      ensure  => present,
+      require => Base::Apt::Repository["lenny"],
+    }
+
+    service { "postgresql-8.3":
+      enable  => true,
+      require => Package["postgresql-8.3"],
+    }
+
+    file { "/etc/postgresql/8.3/main/postgresql.conf":
+      owner   => root,
+      group   => root,
+      mode    => 755,
+      source  => "puppet://$servername/modules/pgsql/postgresql.conf",
+      require => Package["postgresql-8.3"], Exec["initial-backup-pg"], File["/etc/sysctl.d/shmmax.conf"],
+      notify  => Service["postgresql-8.3"],
+    }
+
+    file { "/etc/postgresql/8.3/main/pg_hba.conf":
+      owner   => root,
+      group   => root,
+      mode    => 755,
+      source  => "puppet://$servername/modules/pgsql/pg_hba.conf",
+      require => Package["postgresql-8.3"],
+      notify  => Service["postgresql-8.3"],
+    }
+
+    # Perform the initial backup of the database once PostgreSQL has been installed.
+    exec { "initial-backup-pg":
+      path        => "/usr/bin:/bin:/usr/sbin:/sbin",
+      command     => "/etc/init.d/postgresql-8.3 stop && cp -a /var/lib/postgresql /tmpfs/postgresql && touch /tmpfs/.pg-backup-done && /etc/init.d/disk-backup stop && /etc/init.d/postgresql-8.3 start",
+      creates     => "/tmpfs/.pg-backup-done",
+      require     => [ Package["postgresql-8.3"], Mount["/tmpfs"], File["/etc/init.d/disk-backup"] ]
+    }
+  }
+}

--- a/modules/testing_bot/manifests/init.pp
+++ b/modules/testing_bot/manifests/init.pp
@@ -33,6 +33,7 @@ class testing_bot {
   # Backup some important data to disk.
   package { "rsync":
     ensure => present,
+    require => Base::Apt::Repository["lenny"]
   }
   file { "/etc/init.d/disk-backup":
     owner   => root,
@@ -54,7 +55,7 @@ class testing_bot {
 
   package { ["drupaltestbot", "drush", "apache2", "libapache2-mod-php5", "curl", "cvs"]:
     ensure => present,
-    require => [ Base::Apt::Repository["drupal.org"], Base::Apt::Repository["php53"], Service["mysql"] ],
+    require => [ Base::Apt::Repository["lenny"], Base::Apt::Repository["drupal.org"], Base::Apt::Repository["php53"], Service["mysql"] ],
   }
 
   # Drush needs to run one time as root to download its prerequisites from PEAR.
@@ -128,6 +129,12 @@ class testing_bot {
   class pgsql {
     # Install and tune the server itself (on tmpfs)
     include "pgsql::server"
+
+    package { "php5-pgsql":
+      ensure => present,
+      require => Base::Apt::Repository["php53"],
+      notify => Service["apache2"],
+    }
 
     package { "drupaltestbot-pgsql":
       ensure => present,

--- a/modules/testing_bot/manifests/init.pp
+++ b/modules/testing_bot/manifests/init.pp
@@ -46,7 +46,7 @@ class testing_bot {
   # environment because the test client itself needs that.
   include "mysql::server"
 
-  package { ["drupaltestbot", "drush", "apache2", "libapache2-mod-php5", "curl", "cvs"]:
+  package { ["drush", "apache2", "libapache2-mod-php5", "curl", "cvs"]:
     ensure => present,
     require => [ Base::Apt::Repository["lenny"], Base::Apt::Repository["drupal.org"], Base::Apt::Repository["php53"], Service["mysql"] ],
   }
@@ -96,7 +96,6 @@ class testing_bot {
 
   package { "drupaltestbot":
     ensure => "0.0.4",
-    require => Exec["initial-backup"],
   }
 
   class mysql {

--- a/modules/testing_bot/manifests/init.pp
+++ b/modules/testing_bot/manifests/init.pp
@@ -95,7 +95,7 @@ class testing_bot {
   }
 
   package { "drupaltestbot":
-    ensure => "0.0.4",
+    ensure => "0.0.5",
   }
 
   class mysql {


### PR DESCRIPTION
Hi again,

Here's the Puppet config to set up a Postgres testbot.

We're running a fork of this with some customisations specific to our company (different sudo groups for our sysadmins etc), and using different apt repositories to get the Lenny and PIFR packages (since they're not available in yours yet).

For this to work, drupaltestbot 0.0.5 will need to be built and put in your repo.

Any testbot with -pgsql at the end of its name will be set up as a Postgres testbot. I haven't tested converting a MySQL bot to a Postgres one, but I suspect the result wouldn't be pretty.

With this setup, MariaDB is put back in its normal location, while Postgres sits on /tmpfs and is backed up on reboot.

Hopefully I haven't screwed with your Puppet stuff too much. I suspect my Puppet skills aren't anywhere near as fancy as yours. I did do a test run building a MySQL bot to make sure that still works, and it did.

Let me know if you have any issues with how I've done something.

Thanks
